### PR TITLE
Update theme_explorer.py

### DIFF
--- a/apps/theme_explorer.py
+++ b/apps/theme_explorer.py
@@ -153,7 +153,7 @@ boostrap_card = html.Div(
                         target="_blank",
                     )
                 ),
-                dcc.Dropdown(id="themes"),
+                dcc.Dropdown(id="themes",clearable=False),
                 make_radio_items("light_dark", ["Light Themes", "Dark Themes"]),
             ]
         ),


### PR DESCRIPTION
Set `clearable=False` to the themes selection dropdown.

Before it allowed to clear the dropdown which breaks the layout of the app.
![HelloDash ](https://user-images.githubusercontent.com/45846529/115507309-93e6bb00-a299-11eb-82bb-0fa1beb0e3fa.gif)



