### PR TITLE
Added vizro themes and templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,4 +65,4 @@ app.layout = dbc.Container(
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run(debug=True)

--- a/assets/1css.css
+++ b/assets/1css.css
@@ -17,6 +17,11 @@ img[src*="#fluid600"] {
 }
 
 
+img[src*="#fluid400"] {
+   max-width: 400px;
+   height:auto;
+}
+
 .accordion-body{
     padding: 0 !important
 }

--- a/assets/dbc.css
+++ b/assets/dbc.css
@@ -2,7 +2,7 @@
 Defines the .dbc class
   Description: The dbc class improves the style of Dash components when using Bootstrap V5 themes
   Author: @AnnMarieW
-  Updated: 2024-08-20
+  Updated: 2025-02-12
 */
 
 
@@ -38,7 +38,7 @@ Defines the .dbc class
 .dbc .Select-control {
   background-color: var(--bs-body-bg) !important;
   border: var(--bs-border-width) solid var(--bs-border-color) !important;
-
+  border-radius: var(--bs-border-radius);
 }
 
 /* changes the text color of input box */
@@ -246,7 +246,7 @@ body .dbc .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-in
 /*---- Sliders ----------------- */
 
 .dbc .rc-slider-track {
-  background-color: rgba(var(--bs-primary-rgb), 0.50);
+  background-color: var(--bs-primary-rgb);
 }
 
 .dbc .rc-slider-handle {
@@ -277,6 +277,10 @@ body .dbc .dash-table-container .dash-spreadsheet-container .dash-spreadsheet-in
   border-color: var(--bs-primary);
 }
 
+.dbc .rc-slider-tooltip-inner {
+  background-color: var(--bs-secondary);
+  border-radius: var(--bs-border-radius);
+}
 
 /* ------------ datepickers -----------------------*/
 

--- a/examples/color_modes.py
+++ b/examples/color_modes.py
@@ -40,7 +40,7 @@ fig = px.scatter(
 
 app.layout = dbc.Container(
     [
-        html.Div(["Bootstrap Light Dark Color Modes Demo"], className="bg-primary text-white h3 p-2"),
+        html.H3(["Bootstrap Light Dark Color Modes Demo"], className="bg-primary  p-2"),
         color_mode_switch,
         dcc.Graph(id="graph", figure= fig, className="border"),
     ]

--- a/examples/figure_templates_4graphs.py
+++ b/examples/figure_templates_4graphs.py
@@ -32,6 +32,7 @@ themes = [
     "vapor",
     "yeti",
     "zephyr",
+    "vizro"
 ]
 
 

--- a/examples/figure_templates_all.py
+++ b/examples/figure_templates_all.py
@@ -39,6 +39,7 @@ themes = [
     "quartz",
     "vapor",
     "zephyr",
+    "vizro"
 ]
 
 dark_themes = [t+"_dark" for t in themes]
@@ -63,7 +64,7 @@ figures = [
     for template in all_templates
 ]
 
-button = dbc.Button("Show all 52 Themes!", id="figure_templates_all-x-btn", n_clicks=0)
+button = dbc.Button("Show all 54 Themes!", id="figure_templates_all-x-btn", n_clicks=0)
 
 app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 

--- a/examples/sample_app.py
+++ b/examples/sample_app.py
@@ -17,7 +17,7 @@ continents = df.continent.unique()
 # stylesheet with the .dbc class to style  dcc, DataTable and AG Grid components with a Bootstrap theme
 dbc_css = "https://cdn.jsdelivr.net/gh/AnnMarieW/dash-bootstrap-templates/dbc.min.css"
 # if using the vizro theme
-vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.34/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 
 app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP, dbc.icons.FONT_AWESOME, dbc_css])
 

--- a/examples/theme_switch2.py
+++ b/examples/theme_switch2.py
@@ -23,7 +23,7 @@ df = pd.DataFrame(
         "City": ["SF", "SF", "SF", "Montreal", "Montreal", "Montreal"],
     }
 )
-header = html.H4("ThemeSwitchAIO Demo", className="bg-primary text-white p-4 mb-2")
+header = html.H4("ThemeSwitchAIO Demo", className="bg-primary p-4 mb-2")
 
 theme_switch = ThemeSwitchAIO(aio_id="theme", themes=[url_theme1, url_theme2])
 

--- a/examples/utl_color_bg.py
+++ b/examples/utl_color_bg.py
@@ -27,10 +27,10 @@ color_bg = html.Div(
 
 color_bg_gradient = html.Div(
     [
-        html.P("bg-primary text-white py-4", className="bg-primary text-white py-4"),
+        html.P("bg-primary py-4", className="bg-primary  py-4"),
         html.P(
-            "bg-primary  bg-gradient text-white py-4",
-            className="bg-primary bg-gradient text-white py-4",
+            "bg-primary  bg-gradient py-4",
+            className="bg-primary bg-gradient  py-4",
         ),
     ],
 )

--- a/examples/utl_interactive.py
+++ b/examples/utl_interactive.py
@@ -16,7 +16,7 @@ input_class_name = dbc.FormFloating(
     [
         dbc.Input(
             type="text",
-            value="bg-primary text-white",
+            value="bg-primary",
             autocomplete="off",
             id="utl-class-name",
         ),

--- a/examples/vizro_figure_templates.py
+++ b/examples/vizro_figure_templates.py
@@ -1,0 +1,40 @@
+
+from dash import Dash, html, dcc, Input, Output, Patch, clientside_callback, callback
+import plotly.express as px
+import plotly.io as pio
+import dash_bootstrap_components as dbc
+
+from dash_bootstrap_templates import load_figure_template
+
+# Load data and figure templates
+gapminder = px.data.gapminder().query("year==2007")
+load_figure_template(["vizro", "vizro_dark"])
+
+vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+app = Dash(__name__, external_stylesheets=[vizro_bootstrap])
+
+light = dcc.Graph(
+    figure=px.scatter(gapminder, x="gdpPercap", y="lifeExp", size="pop", size_max=60, color="continent")
+)
+
+
+dark = dcc.Graph(
+    figure=px.scatter(gapminder, x="gdpPercap", y="lifeExp", size="pop", size_max=60, color="continent", template="vizro_dark")
+)
+
+tabs = dbc.Tabs(
+    [
+        dbc.Tab(light, label="vizro_light"),
+        dbc.Tab(dark, label="vizro_dark"),
+    ]
+)
+
+
+app.layout = dbc.Container(
+    [html.H1("Vizro Bootstrap Template Demo", className="bg-primary p-2 mt-4"),  tabs],
+    fluid=True,
+)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/vizro_figure_templates.py
+++ b/examples/vizro_figure_templates.py
@@ -1,7 +1,6 @@
 
-from dash import Dash, html, dcc, Input, Output, Patch, clientside_callback, callback
+from dash import Dash, html, dcc
 import plotly.express as px
-import plotly.io as pio
 import dash_bootstrap_components as dbc
 
 from dash_bootstrap_templates import load_figure_template
@@ -10,7 +9,7 @@ from dash_bootstrap_templates import load_figure_template
 gapminder = px.data.gapminder().query("year==2007")
 load_figure_template(["vizro", "vizro_dark"])
 
-vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.34/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 app = Dash(__name__, external_stylesheets=[vizro_bootstrap])
 
 light = dcc.Graph(

--- a/examples/vizro_theme_switch.py
+++ b/examples/vizro_theme_switch.py
@@ -1,0 +1,78 @@
+
+from dash import Dash, html, dcc, Input, Output, Patch, clientside_callback, callback
+import plotly.express as px
+import plotly.io as pio
+import dash_bootstrap_components as dbc
+
+from dash_bootstrap_templates import load_figure_template
+
+# Load data and figure templates
+gapminder = px.data.gapminder().query("year==2007")
+load_figure_template(["vizro", "vizro_dark"])
+
+
+# Alternatively, you could do:
+# You need to install vizro>=0.1.34
+#import vizro
+#app = Dash(__name__, external_stylesheets=[vizro.bootstrap])
+
+vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+app = Dash(__name__, external_stylesheets=[vizro_bootstrap])
+
+# Create components for the dashboard
+color_mode_switch = html.Span(
+    [
+        dbc.Label(className="fa fa-moon", html_for="vizro-switch"),
+        dbc.Switch(id="vizro-switch", value=False, className="d-inline-block ms-1"),
+        dbc.Label(className="fa fa-sun", html_for="vizro-switch"),
+    ]
+)
+scatter = dcc.Graph(
+    id="vizro-scatter", figure=px.scatter(gapminder, x="gdpPercap", y="lifeExp", size="pop", size_max=60, color="continent")
+)
+box = dcc.Graph(id="vizro-box", figure=px.box(gapminder, x="continent", y="lifeExp", color="continent"))
+
+
+tabs = dbc.Tabs(
+    [
+        dbc.Tab(box, label="Box Plot"),
+        dbc.Tab(scatter, label="Scatter Plot"),
+    ]
+)
+
+app.layout = dbc.Container(
+    [html.H3("Vizro Bootstrap Demo", className="bg-primary p-2 mt-4"), color_mode_switch, tabs],
+    fluid=True,
+)
+
+
+# Add callbacks to switch between dark / light
+@callback(
+    [Output("vizro-scatter", "figure"), Output("vizro-box", "figure")],
+    Input("vizro-switch", "value"),
+)
+def update_figure_template(switch_on):
+    """Sync the figure template with the color mode switch on the bootstrap template."""
+    template = pio.templates["vizro"] if switch_on else pio.templates["vizro_dark"]
+    patched_figure = Patch()
+    patched_figure["layout"]["template"] = template
+
+    return patched_figure, patched_figure
+
+
+clientside_callback(
+    """
+    (switchOn) => {
+       switchOn
+         ? document.documentElement.setAttribute('data-bs-theme', 'light')
+         : document.documentElement.setAttribute('data-bs-theme', 'dark')
+       return window.dash_clientside.no_update
+    }
+    """,
+    Output("vizro-switch", "id"),
+    Input("vizro-switch", "value"),
+)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/examples/vizro_theme_switch.py
+++ b/examples/vizro_theme_switch.py
@@ -17,7 +17,7 @@ load_figure_template(["vizro", "vizro_dark"])
 #app = Dash(__name__, external_stylesheets=[vizro.bootstrap])
 
 vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
-app = Dash(__name__, external_stylesheets=[vizro_bootstrap])
+app = Dash(__name__, external_stylesheets=[vizro_bootstrap, dbc.icons.FONT_AWESOME])
 
 # Create components for the dashboard
 color_mode_switch = html.Span(

--- a/examples/vizro_theme_switch.py
+++ b/examples/vizro_theme_switch.py
@@ -16,7 +16,7 @@ load_figure_template(["vizro", "vizro_dark"])
 #import vizro
 #app = Dash(__name__, external_stylesheets=[vizro.bootstrap])
 
-vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.34/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 app = Dash(__name__, external_stylesheets=[vizro_bootstrap, dbc.icons.FONT_AWESOME])
 
 # Create components for the dashboard

--- a/lib/nav.py
+++ b/lib/nav.py
@@ -46,7 +46,7 @@ vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/s
 theme_changer = ThemeChangerAIO(
     aio_id="theme",
     button_props={"color": "primary", "outline": True},
-    radio_props={"persistence": True},
+    radio_props={"persistence": True, "value": dbc.themes.SPACELAB},
     custom_themes={'Vizro': vizro_boostrap},
 )
 

--- a/lib/nav.py
+++ b/lib/nav.py
@@ -41,11 +41,13 @@ multi_page_app_demos = "https://github.com/AnnMarieW/dash-multi-page-app-demos"
 formattable_url = "https://formattable.pythonanywhere.com/"
 legend_and_annotations = "https://plotly-annotations.herokuapp.com/"
 
+vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 
 theme_changer = ThemeChangerAIO(
     aio_id="theme",
     button_props={"color": "primary", "outline": True},
-    radio_props={"value": dbc.themes.SPACELAB, "persistence": True},
+    radio_props={"persistence": True},
+    custom_themes={'Vizro': vizro_boostrap},
 )
 
 
@@ -57,7 +59,7 @@ color_mode_switch =  html.Span(
     ]
 )
 
-# The ThemeChangerAIO loads all 52  Bootstrap themed figure templates to plotly.io
+# The ThemeChangerAIO loads all 54  Bootstrap themed figure templates to plotly.io
 theme_controls = html.Div(
     [theme_changer, color_mode_switch],
     className="hstack gap-3"
@@ -67,7 +69,7 @@ theme_controls = html.Div(
 def make_header(text, spacing="mt-4"):
     return html.H2(
         text,
-        className="text-white bg-primary p-2 " + spacing,
+        className="bg-primary p-2 " + spacing,
     )
 
 

--- a/lib/nav.py
+++ b/lib/nav.py
@@ -338,7 +338,6 @@ def make_side_nav():
     Input("url", "pathname")
 )
 def update_vizro_theme_on_vizro_page(url):
-    print(url)
     if url =="/adding-themes/vizro-bootstrap":
         return vizro_boostrap
     return dash.no_update

--- a/lib/nav.py
+++ b/lib/nav.py
@@ -333,3 +333,13 @@ def make_side_nav():
 
     )
 
+@callback(
+    Output(ThemeChangerAIO.ids.radio("theme"), "value"),
+    Input("url", "pathname")
+)
+def update_vizro_theme_on_vizro_page(url):
+    print(url)
+    if url =="/adding-themes/vizro-bootstrap":
+        return vizro_boostrap
+    return dash.no_update
+

--- a/lib/nav.py
+++ b/lib/nav.py
@@ -41,7 +41,7 @@ multi_page_app_demos = "https://github.com/AnnMarieW/dash-multi-page-app-demos"
 formattable_url = "https://formattable.pythonanywhere.com/"
 legend_and_annotations = "https://plotly-annotations.herokuapp.com/"
 
-vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.34/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 
 theme_changer = ThemeChangerAIO(
     aio_id="theme",

--- a/pages/adding_themes/color_modes.py
+++ b/pages/adding_themes/color_modes.py
@@ -161,12 +161,12 @@ The Bootstrap theme is automatically applied __only__ to `dbc` components.  If y
 ## Applying Bootstrap themes to figures
 When you change the color mode, the figures are not updated automatically.  One option is to update the figure template in
  a callback.  The built-in "plotly_white" and "plotly_dark" figure templates look nice with most Bootstrap themes.  If
-  you would like your figures to have a closer match to your Bootstrap theme, you can use one of the 52 Bootstrap themed
+  you would like your figures to have a closer match to your Bootstrap theme, you can use one of the 54 Bootstrap themed
    figure templates from the [dash-bootstrap-templates](https://github.com/AnnMarieW/dash-bootstrap-templates) library.
   For more information see the <dccLink href="/adding-themes/figure-templates" children="Figure Templates" /> section.
 
 The dash-bootstrap-templates >= V1.1.0  has a dark and light version of each of the 26 Bootstrap themes in the dbc
- library.
+ library.  V2.1.0 uses Plolty 6.0.0 and includes the Vizro light and dark themes.
  
  
  

--- a/pages/adding_themes/figure_templates.py
+++ b/pages/adding_themes/figure_templates.py
@@ -113,7 +113,7 @@ load_figure_template(["sketchy", "cyborg", "minty"])
 ```
 This loads the named figure templates into `plotly.io.templates` and sets the first item in the list as the default.
   
-If you would like to make all 52 figure templates available in your app use:
+If you would like to make all 54 figure templates available in your app use:
 
 ```
 load_figure_template(["all"])

--- a/pages/adding_themes/theme_switch.py
+++ b/pages/adding_themes/theme_switch.py
@@ -179,7 +179,61 @@ ThemeChangerAIO(
     },
 )
 ```
-  
+
+#### ThemeChangerAIO with custom themes
+
+By default this component includes the 26 themes available from the dash-bootstrap-components library.  Use the `custom_themes`
+prop to add themes.   This example adds the Vizro theme:
+
+```
+vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+
+theme_changer = ThemeChangerAIO(
+    aio_id="theme",   
+    custom_themes={'Vizro': vizro_boostrap},
+)
+```
+
+Available in `dash-bootstrap-templates>=V1.0.8`
+
+
+### ThemeChangerAIO with local stylesheets 
+
+This is how to use local stylesheets stored in the assets folder with ThemeChangerAIO. Each theme should have its own separate file.
+
+```python
+
+theme_changer = ThemeChangerAIO(
+    aio_id="theme",   
+    custom_themes={
+        'vizro': "vizro.css",
+        'custom": "my-custom-theme.css"
+    },
+)
+```
+
+To override the default themes in the Radio components set the `options` in the `radio_props`:
+
+```
+ThemeChangerAIO(
+    radio_props={
+        "options": [
+            {"label": "Cyborg", "value": dbc.themes.CYBORG},
+            {"label": "My Theme", "value": "custom_light_theme.css"},
+            {"label": "My Dark Theme", "value": "custom_dark_theme.css"},
+            {"label": "Spacelab", "value": dbc.themes.SPACELAB},       
+        ],
+        "value": dbc.themes.CYBORG,
+    },
+    # other props....
+)
+```
+
+Available in `dash-bootstrap-templates>=V1.0.8`
+
+
+
+
 #### ThemeChangerAIO menu position
 This ThemeChangerAIO will open the `Offcanvas` component on the bottom of the screen:
 
@@ -211,29 +265,31 @@ If you are starting with a dark theme, swap the position of the icons:
 
 
 reference = """
-## ThemeChangerAIO Reference
-**ThemeChangerAIO** is an All-in-One component  composed  of a parent `html.Div` with
-the following components as children:
 
-- `dbc.Button` ("`switch`") Opens the Offcanvas component for user to select a theme
+## ThemeChangerAIO Reference 
+**ThemeChangerAIO** is an All-in-One component  composed  of a parent `html.Div` with the following components as children:
+
+- `dbc.Button` ("`switch`") Opens the Offcanvas component for user to select a theme.
 - `dbc.Offcanvas` ("`offcanvas`")
-- `dbc.RadioItems` ("`radio`").  The themes are displayed as RadioItems inside the `dbc.Offcanvas` component
-  The `value` is a url for the theme
-- `html.Div` is used as the `Output` of the clientside callbacks
+- `dbc.RadioItems` ("`radio`").  The themes are displayed as RadioItems inside the `dbc.Offcanvas` component.
+  The `value` is a url for the theme or the file name of a .css file in the /assets folder.
+- Two `dcc.Store` used as `Input` of the clientside callbacks to provide the theme list and the assets path.
 
-The `ThemeChangerAIO` component updates the stylesheet  when the `value` of radio changes. (i.e. the user selects a new theme)
+The ThemeChangerAIO component updates the stylesheet  when the `value` of radio changes. (ie the user selects a new theme)
 
 - param: `radio_props` A dictionary of properties passed into the dbc.RadioItems component. The default `value` is `dbc.themes.BOOTSTRAP`
-- param: `button_props`  A dictionary of properties passed into the dbc.Button component
+- param: `button_props`  A dictionary of properties passed into the dbc.Button component.
 - param: `offcanvas_props`. A dictionary of properties passed into the dbc.Offcanvas component
-- param: `aio_id` The All-in-One component ID used to generate components' dictionary IDs
+- param: `aio_id` The All-in-One component ID used to generate components' dictionary IDs.
+- param: `custom_themes` A dictionary of local .css files or external url
+    with the keys being the theme name and the value being the theme path (file name in assets folder or url).
+- param: `custom_dark_themes` List of custom dark theme name, so that they appear with a black background in the offcanvas list.
 
 The All-in-One component dictionary IDs are available as:
 
-- `ThemeChangerAIO.ids.radio(aio_id)`
-- `ThemeChangerAIO.ids.offcanvas(aio_id)`
-- `ThemeChangerAIO.ids.button(aio_id)`
-    
+- ThemeChangerAIO.ids.radio(aio_id)
+- ThemeChangerAIO.ids.offcanvas(aio_id)
+- ThemeChangerAIO.ids.button(aio_id)
 
 ## ThemeSwitchAIO Reference
 

--- a/pages/adding_themes/theme_switch.py
+++ b/pages/adding_themes/theme_switch.py
@@ -186,7 +186,7 @@ By default this component includes the 26 themes available from the dash-bootstr
 prop to add themes.   This example adds the Vizro theme:
 
 ```
-vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.34/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 
 theme_changer = ThemeChangerAIO(
     aio_id="theme",   

--- a/pages/adding_themes/vizro_bootstrap.py
+++ b/pages/adding_themes/vizro_bootstrap.py
@@ -1,0 +1,138 @@
+from dash import html, dcc, register_page
+import dash_bootstrap_components as dbc
+
+from lib.code_and_show import example_app, make_app_first, make_tabs
+from lib.utils import app_description, theme_dark_md, themes_light_md
+
+
+register_page(
+    __name__,
+    order=4,
+    description=app_description,
+    title="Vizro Bootstrap Theme",
+    name="Vizro Bootstrap Theme",
+)
+
+intro = """
+
+## Vizro Bootstrap Theme
+Along with the 26 themes available in the dash-bootstrap-components library, you can now also style your dash app with a Vizro theme!
+
+Learn more at [Vizro](), and the [Visual Vocabulary](https://vizro-demo-visual-vocabulary.hf.space/) site.
+
+` `
+` `
+
+-----   
+
+
+
+![image](https://github.com/user-attachments/assets/e82ef1d4-a2aa-4e86-9882-94611d47b24b#fluid400)
+![image](https://github.com/user-attachments/assets/0b66409a-a100-43c8-b96e-cc6b3b0055fd#fluid400)
+
+-------------
+
+` `
+` `
+
+### What is Vizro?  
+
+[Vizro](https://github.com/plotly/Vizro) is an open-source dashboarding framework developed by McKinsey. Built with Plotly and Dash, Vizro provides a high-level API for creating interactive, production-ready dashboards with minimal code. It includes pre-configured layouts, themes, and components, making it easier to build data-driven applications.  
+
+
+Even if you're not creating a Vizro app, you can still use its styling and design system in your Dash applications.  
+
+### Vizro Features Available for Dash Apps  
+
+- Vizro Bootstrap-themed figure templates are available in the dash-bootstrap-templates library starting from version 2.1.0. Both dark and light-themed templates are included.  
+
+- Vizro Bootstrap theme provides styling for Bootstrap components, allowing them to match the Vizro light or dark theme.  
+
+- Vizro theme for other Dash components extends styling beyond Bootstrap. Vizro includes custom CSS to theme additional Dash components that are not part of Bootstrap. You can explore all the custom CSS files in their [GitHub repository](https://github.com/mckinsey/vizro/tree/main/vizro-core/src/vizro/static/css).  
+
+- Vizro KPI cards can be added to a regular Dash app, bringing a visually consistent way to display key performance indicators. For more details, see this [Plotly forum post](https://community.plotly.com/t/introducing-new-kpi-cards-in-vizro-based-on-dbc/86711).  
+
+
+### Vizro Bootstrap Figure Templates
+
+Learn more about [figure templates](https://hellodash.pythonanywhere.com/adding-themes/figure-templates)
+
+Make Vizro templates available in your app:
+
+```
+from dash_bootstrap_templates import load_figure_template
+load_figure_template(["vizro", "vizro_dark"])
+```
+
+The default theme for all Plotly figures in the app will be "vizro" which is the light theme.  To change it to the "vizro_dark" theme:
+
+```
+fig=px.scatter(gapminder, x="gdpPercap", y="lifeExp", size="pop", size_max=60, color="continent", template="vizro_dark")
+
+```
+"""
+
+theme_switch = """
+
+### Vizro Bootstrap Theme
+
+You can add the Vizro Bootstrap theme to your app like this:
+
+```
+pip install vizro>=0.1.34
+```
+
+```
+import vizro
+from dash import Dash
+app = Dash(__name__, external_stylesheets=[vizro.bootstrap])
+
+```
+You can also use the Vizro Bootstrap theme without importing vizro in your app.  The `vizro.bootstrap` is a is a predefined URL that links to the Vizro Bootstrap CSS stylesheet.  To find the link you can use
+
+```
+print(vizro.bootstrap)
+```
+
+You can then use it in your app like this:
+
+```
+vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+app = Dash(__name__, external_stylesheets=[vizro_bootstrap])
+
+```
+
+
+
+
+
+"""
+
+
+next = """
+-----------------  
+
+### Next:  
+Adding a  <dccLink href="/adding-themes/theme-switch" children="Theme change component" />
+
+"""
+
+
+layout = html.Div(
+    [
+        dcc.Markdown(intro, dangerously_allow_html=True, className="mx-5 px-3"),
+        example_app("vizro_figure_templates", make_layout=make_tabs),
+
+        dcc.Markdown(theme_switch, dangerously_allow_html=True, className="mx-5 px-3"),
+        example_app("vizro_theme_switch", make_layout=make_tabs),
+
+
+        dcc.Markdown(
+            next,
+            className="m-5 px-3 dbc",
+            dangerously_allow_html=True,
+        ),
+
+    ],
+    className="dbc",
+)

--- a/pages/adding_themes/vizro_bootstrap.py
+++ b/pages/adding_themes/vizro_bootstrap.py
@@ -149,7 +149,6 @@ layout = html.Div(
             make_layout=make_app_first,
             run=False,
         ), className="mx-4"),
-        # example_app("vizro_theme_switch", make_layout=make_tabs),
 
         dcc.Markdown(theme_change, dangerously_allow_html=True, className="mx-5 px-3"),
 

--- a/pages/adding_themes/vizro_bootstrap.py
+++ b/pages/adding_themes/vizro_bootstrap.py
@@ -16,7 +16,7 @@ register_page(
 intro = """
 
 ## Vizro Bootstrap Theme
-Along with the 26 themes available in the dash-bootstrap-components library, you can now also style your dash app with a Vizro theme!
+In addition to the 26 themes available in the dash-bootstrap-components library, you can now style your Dash app with a Vizro theme as well!
 
 Learn more at [Vizro](), and the [Visual Vocabulary](https://vizro-demo-visual-vocabulary.hf.space/) site.
 
@@ -44,25 +44,27 @@ Even if you're not creating a Vizro app, you can still use its styling and desig
 
 ### Vizro Features Available for Dash Apps  
 
-- Vizro Bootstrap-themed figure templates are available in the dash-bootstrap-templates library starting from version 2.1.0. Both dark and light-themed templates are included.  
+- **Vizro Bootstrap-themed figure templates** are available in the dash-bootstrap-templates library starting from version 2.1.0. Both dark and light-themed templates are included.  
 
-- Vizro Bootstrap theme provides styling for Bootstrap components, allowing them to match the Vizro light or dark theme.  
+- **Vizro Bootstrap theme** provides styling for Bootstrap components, allowing them to match the Vizro light or dark theme.  
 
-- Vizro theme for other Dash components extends styling beyond Bootstrap. Vizro includes custom CSS to theme additional Dash components that are not part of Bootstrap. You can explore all the custom CSS files in their [GitHub repository](https://github.com/mckinsey/vizro/tree/main/vizro-core/src/vizro/static/css).  
+- **Vizro theme for other Dash components** extends styling beyond Bootstrap. Vizro includes custom CSS to theme additional Dash components that are not part of Bootstrap. You can explore all the custom CSS files in their [GitHub repository](https://github.com/mckinsey/vizro/tree/main/vizro-core/src/vizro/static/css).  
 
-- Vizro KPI cards can be added to a regular Dash app, bringing a visually consistent way to display key performance indicators. For more details, see this [Plotly forum post](https://community.plotly.com/t/introducing-new-kpi-cards-in-vizro-based-on-dbc/86711).  
+- **Vizro KPI cards** like the ones shown in the image above can be added to a regular Dash app, bringing a visually consistent way to display key performance indicators. For more details, see this [Plotly forum post](https://community.plotly.com/t/introducing-new-kpi-cards-in-vizro-based-on-dbc/86711).  
 
 
 ### Vizro Bootstrap Figure Templates
 
-Learn more about [figure templates](https://hellodash.pythonanywhere.com/adding-themes/figure-templates)
+Apply Vizro-themed styling to all Plotly figures in your Dash app. Learn more in the <dccLink href="/adding-themes/figure-templates" children="Figure templates section" /> 
+
+Available in `dash-bootstrap-templates>=V2.1.0`
 
 Make Vizro templates available in your app:
-
 ```
 from dash_bootstrap_templates import load_figure_template
 load_figure_template(["vizro", "vizro_dark"])
 ```
+
 
 The default theme for all Plotly figures in the app will be "vizro" which is the light theme.  To change it to the "vizro_dark" theme:
 
@@ -101,10 +103,26 @@ vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/sr
 app = Dash(__name__, external_stylesheets=[vizro_bootstrap])
 
 ```
+### Example: Vizro light dark color mode
+"""
 
+theme_change = """
+### Adding Vizro theme to ThemeChangerAIO
 
+If you would like to switch between multiple themes, use the <dccLink href="/adding-themes/theme-switch" children="ThemeChangerAIO component" />
 
+By default this component includes the 26 themes available from the dash-bootstrap-components library.  If you would like
+to add custom themes, like Vizo, you can use the `custom_themes` prop:
 
+```
+
+vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+
+theme_changer = ThemeChangerAIO(
+    aio_id="theme",   
+    custom_themes={'Vizro': vizro_boostrap},
+)
+```
 
 """
 
@@ -125,6 +143,8 @@ layout = html.Div(
 
         dcc.Markdown(theme_switch, dangerously_allow_html=True, className="mx-5 px-3"),
         example_app("vizro_theme_switch", make_layout=make_tabs),
+
+        dcc.Markdown(theme_change, dangerously_allow_html=True, className="mx-5 px-3"),
 
 
         dcc.Markdown(

--- a/pages/adding_themes/vizro_bootstrap.py
+++ b/pages/adding_themes/vizro_bootstrap.py
@@ -99,11 +99,13 @@ print(vizro.bootstrap)
 You can then use it in your app like this:
 
 ```
-vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@main/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+vizro_bootstrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.34/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 app = Dash(__name__, external_stylesheets=[vizro_bootstrap])
 
 ```
 ### Example: Vizro light dark color mode
+
+![Vizro Theme switch](https://github.com/user-attachments/assets/ec8d3994-5619-4ad5-b5a8-c47574720677#fluid600)
 """
 
 theme_change = """
@@ -116,7 +118,7 @@ to add custom themes, like Vizo, you can use the `custom_themes` prop:
 
 ```
 
-vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.33/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
+vizro_boostrap = "https://cdn.jsdelivr.net/gh/mckinsey/vizro@0.1.34/vizro-core/src/vizro/static/css/vizro-bootstrap.min.css"
 
 theme_changer = ThemeChangerAIO(
     aio_id="theme",   
@@ -142,7 +144,12 @@ layout = html.Div(
         example_app("vizro_figure_templates", make_layout=make_tabs),
 
         dcc.Markdown(theme_switch, dangerously_allow_html=True, className="mx-5 px-3"),
-        example_app("vizro_theme_switch", make_layout=make_tabs),
+        html.Div(example_app(
+            "vizro_theme_switch",
+            make_layout=make_app_first,
+            run=False,
+        ), className="mx-4"),
+        # example_app("vizro_theme_switch", make_layout=make_tabs),
 
         dcc.Markdown(theme_change, dangerously_allow_html=True, className="mx-5 px-3"),
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dash>=2.14.0
-dash-bootstrap-templates>=1.1.0
+dash-bootstrap-templates>=2.1.0
 dash-bootstrap-components>=1.6.0
 pandas
 dash-ag-grid>=31.0.0
+plotly>=6.0.0


### PR DESCRIPTION
This PR adds the Vizro figure templates from the dash-bootstrap-templates library and adds the Vizro Bootstrap theme

:construction: Do not merge until dash-bootstrap-templates 1.1.0 is released

- [x] updated various example to work better with Vizro
- [x] use the URL rather than importing Vizro and using vizro.bootstrap
- [x] Add new vizro chapter
- [x] Add info to `ThemeChangerAIO` section on adding custom themes
- [x] Review and fix dependencies - Plolty 6 and dbt=2.1.0.  Keep dash at 2.18.2 for now. 
